### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ N/A
 
 ## Usage
 
-To use the website, you would use this link: https://zubeidadhupli.github.io/repository .The link should take you to where the webpage is live on GitHub Pages. When you make the screen smaller, the screen should be responsive as Bootstrap is mobile-first. This was done so that the website would be easier to navigate on smaller devices. I have also added box shadows to the contact icons so that when you hover on them, the icons stand out more. Here is a screenshot that shows the box shadow in action: ![image of icons with shadow when hovering](./images/hover-box-shadow.png) .
+To use the website, you would use this link: https://zubeidadhupli.github.io/Bootstrap-Portfolio/ .The link should take you to where the webpage is live on GitHub Pages. When you make the screen smaller, the screen should be responsive as Bootstrap is mobile-first. This was done so that the website would be easier to navigate on smaller devices. I have also added box shadows to the contact icons so that when you hover on them, the icons stand out more. Here is a screenshot that shows the box shadow in action: ![image of icons with shadow when hovering](./images/hover-box-shadow.png) .
 ## License
 
 MIT license that was chosen when I first created the repository.


### PR DESCRIPTION
In this PR, I have fixed a typo in the README so that the link to the Bootstrap Portfolio webpage should work.